### PR TITLE
Added SERVICEURL to NOIPURL

### DIFF
--- a/no-ip.sh
+++ b/no-ip.sh
@@ -62,7 +62,7 @@ USERAGENT="--user-agent=\"no-ip shell script/1.0 mail@mail.com\""
 BASE64AUTH=$(echo '"$USER:$PASSWORD"' | base64)
 AUTHHEADER="--header=\"Authorization: $BASE64AUTH\""
 
-NOIPURL="https://$USER:$PASSWORD@www.duckdns.org/v3/update"
+NOIPURL="https://$USER:$PASSWORD@$SERVICEURL"
 
 
 if [ -n "$IP" ] || [ -n "$HOSTNAME" ]


### PR DESCRIPTION
Final NOIPURL wasn't pulling in the SERVICEURL so it was only working for duckdns. Pulls in the correct services url now. Confirmed it pulls in the correct URL now and confirmed working for DynDNS. Have not tested functionality for other services.