### PR TITLE
Adds IPv6 support

### DIFF
--- a/no-ip.sh
+++ b/no-ip.sh
@@ -95,7 +95,7 @@ then
 	NOIPURL="${NOIPURL}myip=$IP"
 	if [ -n "$IPV6" ]
 	then
-		NOIPURL="${NOIPURL},$IPV6"
+		NOIPURL="${NOIPURL},$IPV6&myipv6=$IPV6"
 	fi
 fi
 

--- a/no-ip.sh
+++ b/no-ip.sh
@@ -23,6 +23,11 @@ fi
 if [ -n "$DETECTIP" ]
 then
 	IP=$(wget -qO- "http://myexternalip.com/raw")
+
+	if [ -n "$IPV6" ]
+	then
+		IPV6=$(wget -q --output-document - http://checkipv6.dyndns.com/ | grep -o "[0-9a-f\:]\{8,\}")
+	fi
 fi
 
 
@@ -88,6 +93,10 @@ then
 		NOIPURL="$NOIPURL&"
 	fi
 	NOIPURL="${NOIPURL}myip=$IP"
+	if [ -n "$IPV6" ]
+	then
+		NOIPURL="${NOIPURL},$IPV6"
+	fi
 fi
 
 

--- a/no-ip.sh
+++ b/no-ip.sh
@@ -24,7 +24,7 @@ if [ -n "$DETECTIP" ]
 then
 	IP=$(wget -qO- "http://myexternalip.com/raw")
 
-	if [ -n "$IPV6" ]
+	if [ -n "$UPDATEIPV6" ]
 	then
 		IPV6=$(wget -q --output-document - http://checkipv6.dyndns.com/ | grep -o "[0-9a-f\:]\{8,\}")
 	fi
@@ -93,7 +93,7 @@ then
 		NOIPURL="$NOIPURL&"
 	fi
 	NOIPURL="${NOIPURL}myip=$IP"
-	if [ -n "$IPV6" ]
+	if [ -n "$UPDATEIPV6" ]
 	then
 		NOIPURL="${NOIPURL},$IPV6&myipv6=$IPV6"
 	fi

--- a/no-ip.sh
+++ b/no-ip.sh
@@ -95,7 +95,7 @@ then
 	NOIPURL="${NOIPURL}myip=$IP"
 	if [ -n "$IPV6" ]
 	then
-		NOIPURL="${NOIPURL},$IPV6"
+		NOIPURL="${NOIPURL}&myipv6=$IPV6"
 	fi
 fi
 

--- a/no-ip.sh
+++ b/no-ip.sh
@@ -95,7 +95,7 @@ then
 	NOIPURL="${NOIPURL}myip=$IP"
 	if [ -n "$IPV6" ]
 	then
-		NOIPURL="${NOIPURL}&myipv6=$IPV6"
+		NOIPURL="${NOIPURL},$IPV6"
 	fi
 fi
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ The envitonmental variables are as follows:
 
 * **IP**: if DETECTIP is not set, you can specify an IP address.
 
-* **IPV6**: If this is set to 1, then the script will detect the external IPv6 address of the service on which the container is running.
+* **UPDATEIPV6**: If this is set to 1, then the script will detect the external IPv6 address of the service on which the container is running.
 
 * **INTERVAL**: How often the script should call the update services in minutes.
 

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@ The envitonmental variables are as follows:
 
 * **IP**: if DETECTIP is not set, you can specify an IP address.
 
+* **IPV6**: If this is set to 1, then the script will detect the external IPv6 address of the service on which the container is running.
+
 * **INTERVAL**: How often the script should call the update services in minutes.
 
 * **SERVICE**: The service you are using. Currently, the script is setup to use Google Domains (google), DuckDNS (duckdns), DynDNS (dyndns), and NO-IP (noip). Set the service to the value in parenthesis.


### PR DESCRIPTION
Adds an environment variable enabling IPv6 updates. Uses a combination of the "old" style of separating IPv4 & IPv6 addresses with a comma (supported by DynDNS) and the "new" style employing the `myipv6` parameter (supported by everyone else).